### PR TITLE
Fixed st-peters-square edge case station

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 package-lock.json
 .env
 .DS_Store
+*.zip

--- a/util/requestParser.js
+++ b/util/requestParser.js
@@ -10,7 +10,8 @@ const types = {
 
 const edgeCaseStops = new Set([
   'ashton-under-lyne',
-  'deansgate-castlefield'
+  'deansgate-castlefield',
+  'st-peters-square',
 ]);
 
 const stationParse = request => {
@@ -31,6 +32,8 @@ const stationParse = request => {
       station = station.replace('-', ' ');
     } else if (station == 'deansgate-castlefield') {
       station = 'deansgate - castlefield';
+    } else if (station == 'st-peters-square') {
+      station = 'st peter\'s square';
     }
   }
   


### PR DESCRIPTION
St peter's square station was causing a problem because of the punctuation. This is now recognised and translated from st-peters-square to st peter's square that the metrolink api recognises. 